### PR TITLE
Fix: ssdpd does not respond to first request

### DIFF
--- a/src/ssdpd.c
+++ b/src/ssdpd.c
@@ -368,7 +368,7 @@ static void ssdp_recv(int sd)
 {
 	ssize_t len;
 	struct sockaddr sa;
-	socklen_t salen;
+	socklen_t salen = sizeof(sa);
 	char buf[MAX_PKT_SIZE + 1];
 
 	memset(buf, 0, sizeof(buf));


### PR DESCRIPTION
For some interfaces, the ssdpd does not respond to the first M-Search packet, as the sockaddr read by the recvfrom function in line 375 is all zeros. However, the client will respond to the requests the are received afterwards.

This is fixed by setting the size of "addrlen" in recvfrom function