### PR TITLE
coverity: Time of check time of use

### DIFF
--- a/src/ssdpd.c
+++ b/src/ssdpd.c
@@ -389,13 +389,17 @@ static void lsb_exit(void)
  */
 static FILE *fopen_cache(char *mode, char *fn, size_t len)
 {
+	FILE *fp;
+
 	snprintf(fn, len, _CACHEDIR "/" PACKAGE_NAME ".cache");
-	if (access(fn, R_OK | W_OK)) {
-		if (!access(_PATH_VARDB, W_OK))
-			snprintf(fn, len, "%s/" PACKAGE_NAME ".cache", _PATH_VARDB);
+	fp = fopen(fn,mode);
+
+	if (!fp) {
+		snprintf(fn, len, "%s/" PACKAGE_NAME ".cache", _PATH_VARDB);
+		fp = fopen(fn,mode);
 	}
 
-	return fopen(fn, mode);
+	return fp;
 }
 
 /* https://en.wikipedia.org/wiki/Universally_unique_identifier */


### PR DESCRIPTION
Proposed fix for coverity TOCTOU issue:

An attacker could change the filename's file association or other attributes between the check and use.
In fopen_cache: A check occurs on a file's attributes before the file is used in a privileged operation, but things may have changed (CWE-367)

Signed-off-by: Raul Porancea <raul.porancea@gmail.com>