### PR TITLE
Fix unintentional periodic busy loop

### DIFF
--- a/src/ssdpd.c
+++ b/src/ssdpd.c
@@ -232,20 +232,21 @@ static void ssdp_recv(int sd)
 
 static void wait_message(time_t tmo)
 {
-	while (1) {
-		int timeout;
+	int timeout = tmo - time(NULL);
 
-		timeout = tmo - time(NULL);
+	do {
 		if (timeout < 0)
 			break;
 
 		if (ssdp_poll(timeout * 1000) == -1) {
-			if (errno == EINTR)
-				break;
-
-			err(1, "Unrecoverable error");
+			if (errno != EINTR)
+				err(1, "Unrecoverable error");
+			break;
 		}
-	}
+
+		timeout = tmo - time(NULL);
+
+	} while (timeout);
 }
 
 static void announce(struct ifsock *ifs, int mod)


### PR DESCRIPTION
The retry logic in wait_message is broken. The only things that will cause the retry loop to exit is either the timeout reaching a negative value or the underlying poll(2) returning with errno EINTR. This means that if the underlying poll(2) hits the timeout and returns zero (no file descriptors ready) wait_message will busy loop for a whole second until the timeout goes from 0 to -1.

The only error condition where a retry should be reasonable is if the poll was interrupted by a signal, but when a signal has occurred we might actually want to break out of the main loop to shutdown.

This patch simplifies the logic of the loop, to only continue to poll if there is non-zero time left until timeout.