### PR TITLE
Fix truncated UUID when reading from cache file

### DIFF
--- a/src/ssdpd.c
+++ b/src/ssdpd.c
@@ -511,7 +511,7 @@ static void uuidgen(void)
 			fclose(fp);
 			goto generate;
 		}
-		buf[strlen(buf) - 1] = 0;
+		buf[sizeof(buf) - 1] = 0;
 		fclose(fp);
 	}
 


### PR DESCRIPTION
This fixes the truncation of the UUID by one character when read from the cache file. Since `buf` already contains a null-terminated string, setting element `strlen(buf) - 1` to 0 effectively removes the last character. I think the original intention of this line was to ensure that the buffer always contains a null-terminated string.